### PR TITLE
Added support for recording network request metadata with BMSAnalytics

### DIFF
--- a/BMSSecurity.podspec
+++ b/BMSSecurity.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
 
     s.source       = { :git => 'https://github.com/ibm-bluemix-mobile-services/bms-clientsdk-swift-security.git', :tag => "v#{s.version}" }
     s.requires_arc = true
-    s.dependency 'BMSCore', '~> 2.0'
+    s.dependency 'BMSCore', '~> 2.2'
     s.source_files = 'Source/**/*.swift', 'Source/Resources/BMSSecurity.h'
     s.ios.deployment_target = '8.0'
 end

--- a/BMSSecurity.xcodeproj/project.pbxproj
+++ b/BMSSecurity.xcodeproj/project.pbxproj
@@ -359,7 +359,6 @@
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/BMSCore.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/BMSAnalyticsAPI.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/RNCryptor.framework",
 			);
 			name = "Run Script";
 			outputPaths = (
@@ -376,7 +375,6 @@
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/BMSCore.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/BMSAnalyticsAPI.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/RNCryptor.framework",
 			);
 			outputPaths = (
 			);

--- a/BMSSecurity.xcodeproj/xcshareddata/xcschemes/BMSSecurityTests.xcscheme
+++ b/BMSSecurity.xcodeproj/xcshareddata/xcschemes/BMSSecurityTests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0810"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DB2BCF9C1C22FB2F0063A673"
+               BuildableName = "BMSSecurityTests.xctest"
+               BlueprintName = "BMSSecurityTests"
+               ReferencedContainer = "container:BMSSecurity.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ibm-bluemix-mobile-services/bms-clientsdk-swift-core" ~> 1.0
+github "ibm-bluemix-mobile-services/bms-clientsdk-swift-core" ~> 2.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "ibm-bluemix-mobile-services/bms-clientsdk-swift-analytics-api" "1.0.1"
-github "ibm-bluemix-mobile-services/bms-clientsdk-swift-core" "1.0.0"
+github "ibm-bluemix-mobile-services/bms-clientsdk-swift-analytics-api" "2.2.0"
+github "ibm-bluemix-mobile-services/bms-clientsdk-swift-core" "2.2.0"

--- a/Source/mca/internal/AuthorizationRequest.swift
+++ b/Source/mca/internal/AuthorizationRequest.swift
@@ -44,7 +44,8 @@ internal class AuthorizationRequest : BaseRequest {
         
         let configuration = URLSessionConfiguration.default
         configuration.timeoutIntervalForRequest = timeout
-        networkSession = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+        urlSession = BMSURLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+        urlSession.isBMSAuthorizationRequest = true
     }
     
     /**
@@ -119,7 +120,8 @@ internal class AuthorizationRequest : BaseRequest {
         
         let configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
         configuration.timeoutIntervalForRequest = timeout
-        networkSession = NSURLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+        urlSession = BMSURLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+        urlSession.isBMSAuthorizationRequest = true
     }
     
     /**


### PR DESCRIPTION
This is required for BMSAnalytics to be able to record network metadata for requests made to MCA-protected backends. 